### PR TITLE
Log correlation ID on requests

### DIFF
--- a/lib/pier_logging/request_logger.rb
+++ b/lib/pier_logging/request_logger.rb
@@ -50,7 +50,7 @@ module PierLogging
         duration: ((ends_at - starts_at)*1000).to_i,
         context: {
           user: get_user_info_from_headers(request_headers),
-          correlation_id: env['action_dispatch.request_id'],
+          correlation_id: request_headers['X-CORRELATION-ID'],
         },
         request: {
           headers: request_headers,

--- a/lib/pier_logging/version.rb
+++ b/lib/pier_logging/version.rb
@@ -1,3 +1,3 @@
 module PierLogging
-  VERSION = "0.1.13"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Log correlation ID based on the `X-CORRELATION-ID` header instead of the ActionDispatcher requestID.