### PR TITLE
Redact any value for which the key is /.*token/

### DIFF
--- a/lib/pier_logging/request_logger.rb
+++ b/lib/pier_logging/request_logger.rb
@@ -7,7 +7,7 @@ module PierLogging
       /^pw$/,
       /^pass$/i,
       /secret/i,
-      /token/i,
+      /.*token/i,
       /api[-._]?key/i,
       /session[-._]?id/i,
       /^connect\.sid$/


### PR DESCRIPTION
## Context
It's common to find fields like `oauth-token`, `user-token`, etc..

## What was done
We changed one of the regexps used to check for fields to redact to `/.*token/`