### PR TITLE
Fix request body getter

### DIFF
--- a/lib/pier_logging/request_logger.rb
+++ b/lib/pier_logging/request_logger.rb
@@ -56,7 +56,7 @@ module PierLogging
         request: {
           headers: request_headers,
           href: request.url,
-          body: parse_body(request.POST)
+          body: parse_body(request.body)
         },
         response: {
           status: status,

--- a/lib/pier_logging/version.rb
+++ b/lib/pier_logging/version.rb
@@ -1,3 +1,3 @@
 module PierLogging
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end


### PR DESCRIPTION
## Context
We were getting request body using the method [POST](https://www.rubydoc.info/gems/rack/1.2.1/Rack/Request#POST-instance_method) that accepts only ` application/x-www-form-urlencoded` and `multipart/form-data`. 
I don't really know why this was working but as we're using the body only for logging purposes and as we are also parsing the data in `parse_body`, we can use the raw received body ([.body](https://www.rubydoc.info/gems/rack/1.2.1/Rack/Request#body-instance_method))

## What was done
We replaced the `request.POST` call by `request.body`