### PR TITLE
Add authorization to REDACT_REPLACE_KEYS

### DIFF
--- a/lib/pier_logging/helpers/redactor.rb
+++ b/lib/pier_logging/helpers/redactor.rb
@@ -12,7 +12,8 @@ module PierLogging
         /token/i,
         /api[-._]?key/i,
         /session[-._]?id/i,
-        /^connect\.sid$/
+        /^connect\.sid$/,
+        /authorization/i
       ].freeze
       REDACT_REPLACE_BY = '*'.freeze
 

--- a/lib/pier_logging/version.rb
+++ b/lib/pier_logging/version.rb
@@ -1,3 +1,3 @@
 module PierLogging
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
## Context
We were not redacting fields with `authorization` keyword and this is a common field

## What was done
The `/authorization/i` regex was added to `REDACT_REPLACE_KEYS` array