### PR TITLE
Remove warning for deprecated method :after_initialize

### DIFF
--- a/lib/pier_logging/logger.rb
+++ b/lib/pier_logging/logger.rb
@@ -6,7 +6,7 @@ module PierLogging
 
     def initialize(*args)
       super
-      after_initialize if respond_to? :after_initialize
+      after_initialize if respond_to?(:after_initialize) && ActiveSupport::VERSION::MAJOR < 6
     end
 
     def create_formatter


### PR DESCRIPTION
# Context
The method `after_initialize` will be deprecated in Rails 6.1:
> DEPRECATION WARNING: Logger don't need to call #after_initialize directly anymore. It will be deprecated without replacement in Rails 6.1.

# Changes
- Calling `after_initialize` only for Rails < 6